### PR TITLE
add an Object to UnserializableData so that it will fail if jboss mar…

### DIFF
--- a/ejb/src/main/java/org/jboss/server/SimpleStatefulSessionBean.java
+++ b/ejb/src/main/java/org/jboss/server/SimpleStatefulSessionBean.java
@@ -49,7 +49,7 @@ public class SimpleStatefulSessionBean implements SessionBeanRemote, IsSerializa
         for (int i = 0; i < MAX; i++) {
             int result = new Random().nextInt(100) * new Random().nextInt(100);
             logger.debugf("Client Thread (%s) - Result: %d", calledFrom, result);
-            grow.add(new UnserializableData("Thread-" + Thread.currentThread().getId(), UUID.randomUUID().toString(), result));
+            grow.add(new UnserializableData("Thread-" + Thread.currentThread().getId(), UUID.randomUUID().toString(), result, new Object()));
         }
         
         int sum = grow.stream().mapToInt(myData -> myData.getResult()).sum();

--- a/ejb/src/main/java/org/jboss/server/UnserializableData.java
+++ b/ejb/src/main/java/org/jboss/server/UnserializableData.java
@@ -21,13 +21,15 @@ public class UnserializableData {
     private String thread;
     private String uuid;
     private int result;
+    private Object notSerializable;
 
-    public UnserializableData(String string, String uuid, int i) {
+    public UnserializableData(String string, String uuid, int i, Object notSerializable) {
         this.thread = string;
         this.uuid = uuid;
         this.result = i;
+        this.notSerializable = notSerializable;
     }
-    
+
     public int getResult() {
         return this.result;
     }    

--- a/rest/src/main/java/org/jboss/server/rest/SimulatePassivationImpl.java
+++ b/rest/src/main/java/org/jboss/server/rest/SimulatePassivationImpl.java
@@ -34,7 +34,7 @@ public class SimulatePassivationImpl implements SimulatePassivation {
 
             int result = new Random().nextInt(100) * new Random().nextInt(100);
 
-            UnserializableData data = new UnserializableData("Thread-" + Thread.currentThread().getId(), UUID.randomUUID().toString(), result);
+            UnserializableData data = new UnserializableData("Thread-" + Thread.currentThread().getId(), UUID.randomUUID().toString(), result, new Object());
             
             logger.infof("trigger passivation on %s", data);
             


### PR DESCRIPTION
…shalling tries to passivate it

Clustering uses this JBoss Marshalling configuration, which if the target class is not an Object will return true, so it will try to serialize even if it does not implement Serializable (which is different than if you were to use Java Serializaion which would fail if the object does not implement Serializable).  So this means you need an Object in the UnserializableData.java so make it fail the Marshalling.

        configuration.setSerializabilityChecker(new SerializabilityChecker() {
            @Override
            public boolean isSerializable(Class<?> targetClass) {
                return (targetClass != Object.class) || SerializabilityChecker.DEFAULT.isSerializable(targetClass);
            }   
        }); 
